### PR TITLE
(fix) payments form workflow

### DIFF
--- a/client/sessionTiles/sessionTileController.js
+++ b/client/sessionTiles/sessionTileController.js
@@ -5,15 +5,27 @@ myApp.controller('sessionTileController', function ($scope, $http, Auth) {
 
   angular.extend($scope, Auth)
 
-  $http({
-    method: 'GET',
-    url: '/client_token'
-  })
-  .then(function (response) {
-    var clientToken = response.data;
-    braintree.setup(clientToken, "dropin", {
-      container: "payment-form" + $scope.session.id
+  
+
+  $scope.initiateReg = function () {
+
+    $http({
+      method: 'GET',
+      url: '/client_token'
+    })
+    .then(function (response) {
+      var clientToken = response.data;
+      braintree.setup(clientToken, "dropin", {
+        container: "payment-form" + $scope.session.id
+      });
+      $scope.registration = $scope.session.id;
     });
-  });
+
+  };
+
+  $scope.closeReg = function () {
+    $scope.registration = 0;
+    $('#payment-form' + $scope.session.id).empty();
+  };
 
 });

--- a/client/session_tile.html
+++ b/client/session_tile.html
@@ -11,14 +11,14 @@
       <p><i>with {{session.User.username}}</i></p>
       <p>{{session.description}}</p>
       <p>{{displayTime(session.startTime)}}</span></p>
-      <a ng-click="registration = session.id">Register</a>
+      <a href="" ng-click="initiateReg()">Register</a>
     </div>
   </div>
 </div>
 
 <div class="register" ng-show='registration === session.id'>
   <div class="card">
-    <div class="close" ng-click="registration = 0">
+    <div class="close" ng-click="closeReg()">
       <i class="material-icons right">close</i>
     </div>
     <form id="checkout{{ session.id }}" method="post" action="/checkout" ng-submit="registration = 0">


### PR DESCRIPTION
- only load braintree payment form when you click register
- remove it from the DOM when you close the form
